### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ausro/hyrinx-launcher/security/code-scanning/1](https://github.com/ausro/hyrinx-launcher/security/code-scanning/1)

To fix the problem, we should add a `permissions` key at the workflow or job level in .github/workflows/go.yml. Since the workflow does not perform any actions requiring write access, the minimal permission required is `contents: read`. Adding this at the root of the workflow applies it to all jobs unless overridden. Edit the workflow by inserting the following block after the `name: Go` line, before the `on:` block. No imports or further definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
